### PR TITLE
Modified sockets so that the initializers aren't all in update. Believe this solves issues for Firefox.

### DIFF
--- a/src/public/js/main.js
+++ b/src/public/js/main.js
@@ -112,29 +112,16 @@ function create() {
     socket = io.connect("http://localhost:3000/", {
         query: `roomId=${roomId}`
     });
-}
 
-const startGameButton = document.getElementById('start');
-
-function startGame() {
-    console.log('BARRRA');
-    socket.emit("start game", {
-        roomId
-    });
-}
-
-if (startGameButton) {
-    startGameButton.addEventListener('click', startGame);
-}
-
-function update() {
     socket.on('connect', () => {
+        console.log('Connected successfully.');
         game.localPlayer.id = socket.id;
         game.players[game.localPlayer.id] = game.localPlayer;
         socket.on('start game', () => {
+            console.log('Received start game event');
             GAME_STARTED = true;
         })
-
+    
         socket.on('new player', (message) => {
             console.log(JSON.stringify(Object.keys(game.players), null, 3));
             if (message.id === game.localPlayer.id) {
@@ -143,7 +130,7 @@ function update() {
                     if (id != game.localPlayer.id) {
                         newPlayer = initPlayer(id);
                         game.players[id] = newPlayer;
-
+    
                     }
                 }
             } else {
@@ -154,15 +141,13 @@ function update() {
                 console.log(newPlayer.id);
             }
         })
-
+    
         socket.on('player moved', (message) => {
-            // console.log(JSON.stringify(message, null, 3));
-            // console.log(game.players);
             avatar = game.players[message.id].character;
             avatar.x = avatar.x + message.movementDelta.xDelta;
             avatar.y = avatar.y + message.movementDelta.yDelta;
         })
-
+    
         socket.on('weapon fired', (message) => {
             const {
                 id,
@@ -172,7 +157,7 @@ function update() {
             gun.fireAngle = fireAngle;
             gun.fire();
         })
-
+    
         socket.on('player hit', (message) => {
             const { id, damage } = message;
             player = game.players[id];
@@ -190,7 +175,7 @@ function update() {
                 // animate HIT
             }
         })
-
+    
         socket.on('respawn', (message) => {
             // Redraw zombie sprite and reset health
         })
@@ -200,13 +185,13 @@ function update() {
             player = game.players[id];
             switchGun(player.gun, gun);
         })
-
+    
         socket.on("err", ({
             message
         }) => {
             console.error(message);
         });
-
+    
         socket.on("room full", () => {
             const errorDialog = document.getElementById("room-full-dialog");
             console.log(errorDialog);
@@ -215,6 +200,21 @@ function update() {
             }
         });
     });
+}
+
+const startGameButton = document.getElementById('start');
+
+function startGame() {
+    socket.emit("start game", {
+        roomId
+    });
+}
+
+if (startGameButton) {
+    startGameButton.addEventListener('click', startGame);
+}
+
+function update() {
     //LocalPlayer
     movementHandler(game.localPlayer.character, game.localPlayer.gun, game.localPlayer.keyboard);
     //Loop through players (move non-LocalPlayer)


### PR DESCRIPTION
By putting the `socket.on` callbacks in `update`, we're constantly resetting the `socket.on` commands, which I guess has (at some point) an overlap where the client doesn't connect successfully, or the client doesn't receive events because its handlers are being overwritten.


It appears as though this solves the Firefox issues that we were encountering earlier.